### PR TITLE
Signed-off-by: Bharath Sakthivel <bharath.sakthivel@ibm.com>

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,122 @@
+{
+  "exclude": {
+    "files": "^.secrets.baseline$",
+    "lines": null
+  },
+  "generated_at": "2022-08-12T07:23:40Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "BoxDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "ghe_instance": "github.ibm.com",
+      "name": "GheDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "README.md": [
+      {
+        "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
+        "is_verified": false,
+        "line_number": 166,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "redstone/__init__.py": [
+      {
+        "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
+        "is_verified": false,
+        "line_number": 44,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "redstone/auth.py": [
+      {
+        "hashed_secret": "1f05a4293ec69860899bcfa8f7027110467b3f56",
+        "is_verified": false,
+        "line_number": 54,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "test/unit/redstone/test_auth.py": [
+      {
+        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
+        "is_verified": false,
+        "line_number": 30,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ]
+  },
+  "version": "0.13.1+ibm.50.dss",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}


### PR DESCRIPTION
ran detect-secrets

As part of “IBM Cloud 3Q2022: FS-IA readiness”, all the IBM/KMS repositories must enable “Detect Secrets” tool [detect secrets](https://w3.ibm.com/w3publisher/detect-secrets), also scan and audit the secrets in their repositories before **8/21/2022**.

In this PR I’ve enabled “detect-secrets” and also scanned this repository. The results are in file `.secrets.baseline`. 

I request that the team audit the potential secrets discovered in this scan.

## Action to take by any contributor of this repo before merging 

 - [ ] Locally, install [detect secret](https://w3.ibm.com/w3publisher/detect-secrets)
 - [ ] Pull this branch
 - [ ] Run detect secret audit on the secrets
 - [ ] Push results to repo

The setup should be quick. The audit itself will take only a few minutes on each repo or maybe 10 minutes on a very large repo.

Installation of secret detect is quick, but there is also a docker method available if you have docker desktop that takes no setup ([Using docker to run detect secrets](https://github.ibm.com/Whitewater/whitewater-detect-secrets/wiki/Developer-Tool-FAQs#docker-setup)).

For further info on detect-secrets please visit: https://w3.ibm.com/w3publisher/detect-secrets/developer-tool

FYI : Henry Grantham, Dinesh Venkatraman
Thanks