### PR TITLE
Add pre_send_fn functionality

### DIFF
--- a/redstone/client.py
+++ b/redstone/client.py
@@ -49,6 +49,15 @@ class TokenAuth(requests.auth.AuthBase):
         return req
 
 
+class Session(requests.Session):
+    def prepare_request(self, request):
+        r = super().prepare_request(request)
+        for hook in self._pre_send_hooks:
+            if hook:
+                r = hook(r)
+        return r
+
+
 class BaseClient(object):
     def __init__(
         self,
@@ -60,7 +69,7 @@ class BaseClient(object):
         credentials=None,
     ):
 
-        self.session = requests.Session()
+        self.session = Session()
         self.session.verify = verify
 
         self.credentials = credentials
@@ -82,6 +91,41 @@ class BaseClient(object):
             self.endpoint_url = endpoint_url
         else:
             self.endpoint_url = self.endpoint_for_region(region)
+
+        self.session._pre_send_hooks = []
+
+    def set_pre_send_fn(self, fn):
+        """
+        Sets the provided function as a hook to be called per request,
+        just before the requests are sent.
+
+        This allows for modifying any aspects of the requests before they
+        are sent, or for recording/logging/tracing purposes.
+
+        The function must handle its own exceptions, and must return a
+        `requests.Request` object.
+
+        If `fn` resolves to false-y then it will not be called. This
+        can be used to remove any hook currently set, by calling
+        `set_pre_send_fn` with `None` type.
+
+        Example::
+
+            def add_header(req):
+                req.headers["X-Trace-ID"] = "my-tracing-id"
+                return req
+
+            client.set_pre_send_fn(add_header)
+            # X-Trace-ID will be set for all requests from this client object
+            for i in client.list_instances():
+                print(i)
+
+            ...
+        """
+        if fn is not None:
+            self.session._pre_send_hooks = [fn]
+        else:
+            self.session._pre_send_hooks = []
 
 
 class IKS(BaseClient):


### PR DESCRIPTION
```python
import redstone


def main():

    def add_header(req):
        req.headers["Authorization"] = "blah"
        req.headers["X-Trace-ID"] = "abcd1234"
        return req

    rc = redstone.service("ResourceController")
    rc.set_pre_send_fn(add_header)

    headers = rc.session.get("http://httpbin.org/headers")
    print(headers.text)


if __name__ == "__main__":
    import logging
    logging.basicConfig(level=logging.DEBUG)
    main()
```

```bash
$ python test_hook.py
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): iam.cloud.ibm.com:443
DEBUG:urllib3.connectionpool:[https://iam.cloud.ibm.com:443](https://iam.cloud.ibm.com/) "POST /oidc/token HTTP/1.1" 200 2368
DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): httpbin.org:80
DEBUG:urllib3.connectionpool:[http://httpbin.org:80](http://httpbin.org/) "GET /headers HTTP/1.1" 200 286
{
  "headers": {
    "Accept": "*/*",
    "Accept-Encoding": "gzip, deflate",
    "Authorization": "blah",
    "Host": "httpbin.org",
    "User-Agent": "python-requests/2.25.1",
    "X-Amzn-Trace-Id": "Root=1-63dab281-1b836a767bdb79722c145d9b",
    "X-Trace-Id": "abcd1234"
  }
}
```