### PR TITLE
Key Actions update

### DIFF
--- a/redstone/client.py
+++ b/redstone/client.py
@@ -632,11 +632,12 @@ class KeyProtect(BaseClient):
 
     def _action(self, key_id, action, jsonable):
         resp = self.session.post(
-            "%s/api/v2/keys/%s" % (self.endpoint_url, key_id),
-            params={"action": action},
+            "%s/api/v2/keys/%s/actions/%s" % (self.endpoint_url, key_id, action),
             json=jsonable,
         )
         self._validate_resp(resp)
+        if resp.status_code == 204:
+            return None
         return resp.json()
 
     def wrap(self, key_id, plaintext, aad=None):
@@ -662,6 +663,19 @@ class KeyProtect(BaseClient):
 
         resp = self._action(key_id, "unwrap", data)
         return base64.b64decode(resp["plaintext"].encode("utf-8"))
+
+    def rewrap(self, key_id, ciphertext, aad=None):
+        # json body needs to be a UTF-8 string
+        if isinstance(ciphertext, bytes):
+            ciphertext = ciphertext.decode("utf-8")
+
+        data = {"ciphertext": ciphertext}
+
+        if aad:
+            data["aad"] = aad
+
+        resp = self._action(key_id, "unwrap", data)
+        return resp
 
     def rotate_key(self, key_id, payload=None):
         data = None

--- a/redstone/client.py
+++ b/redstone/client.py
@@ -68,7 +68,6 @@ class BaseClient(object):
         endpoint_url=None,
         credentials=None,
     ):
-
         self.session = Session()
         self.session.verify = verify
 
@@ -129,7 +128,6 @@ class BaseClient(object):
 
 
 class IKS(BaseClient):
-
     names = ["iks"]
 
     def __init__(self, *args, **kwargs):
@@ -445,7 +443,6 @@ class ResourceController(BaseClient):
         return resp.json().get("guid"), resp.json().get("id")
 
     def _create_instance_v1(self, name, region, resource_group_id, resource_plan_id):
-
         # seems like the target_crn is the region selector,
         # and its just the price plan ID with the region stuck at the end
         target_crn = (
@@ -594,7 +591,6 @@ class KeyProtect(BaseClient):
     def create_key(
         self, name, payload=None, raw_payload=None, root=False, alias_list=None
     ):
-
         data = {
             "metadata": {
                 "collectionType": "application/vnd.ibm.kms.key+json",
@@ -870,7 +866,6 @@ class KeyProtect(BaseClient):
         self._validate_resp(resp)
 
     def _set_policy(self, resources_list, key_id=None):
-
         collection_total = len(resources_list)
         data = {
             "metadata": {
@@ -1114,7 +1109,6 @@ class CISAuth(requests.auth.AuthBase):
 
 
 class CIS(BaseClient):
-
     names = ["cis"]
 
     def __init__(self, *args, **kwargs):

--- a/redstone/client.py
+++ b/redstone/client.py
@@ -670,7 +670,7 @@ class KeyProtect(BaseClient):
         if aad:
             data["aad"] = aad
 
-        resp = self._action(key_id, "unwrap", data)
+        resp = self._action(key_id, "rewrap", data)
         return resp
 
     def rotate_key(self, key_id, payload=None):

--- a/redstone/client.py
+++ b/redstone/client.py
@@ -49,15 +49,6 @@ class TokenAuth(requests.auth.AuthBase):
         return req
 
 
-class Session(requests.Session):
-    def prepare_request(self, request):
-        r = super().prepare_request(request)
-        for hook in self._pre_send_hooks:
-            if hook:
-                r = hook(r)
-        return r
-
-
 class BaseClient(object):
     def __init__(
         self,
@@ -69,7 +60,7 @@ class BaseClient(object):
         credentials=None,
     ):
 
-        self.session = Session()
+        self.session = requests.Session()
         self.session.verify = verify
 
         self.credentials = credentials
@@ -91,41 +82,6 @@ class BaseClient(object):
             self.endpoint_url = endpoint_url
         else:
             self.endpoint_url = self.endpoint_for_region(region)
-
-        self.session._pre_send_hooks = []
-
-    def set_pre_send_fn(self, fn):
-        """
-        Sets the provided function as a hook to be called per request,
-        just before the requests are sent.
-
-        This allows for modifying any aspects of the requests before they
-        are sent, or for recording/logging/tracing purposes.
-
-        The function must handle its own exceptions, and must return a
-        `requests.Request` object.
-
-        If `fn` resolves to false-y then it will not be called. This
-        can be used to remove any hook currently set, by calling
-        `set_pre_send_fn` with `None` type.
-
-        Example::
-
-            def add_header(req):
-                req.headers["X-Trace-ID"] = "my-tracing-id"
-                return req
-
-            client.set_pre_send_fn(add_header)
-            # X-Trace-ID will be set for all requests from this client object
-            for i in client.list_instances():
-                print(i)
-
-            ...
-        """
-        if fn is not None:
-            self.session._pre_send_hooks = [fn]
-        else:
-            self.session._pre_send_hooks = []
 
 
 class IKS(BaseClient):
@@ -632,11 +588,12 @@ class KeyProtect(BaseClient):
 
     def _action(self, key_id, action, jsonable):
         resp = self.session.post(
-            "%s/api/v2/keys/%s" % (self.endpoint_url, key_id),
-            params={"action": action},
+            "%s/api/v2/keys/%s/actions/%s" % (self.endpoint_url, key_id, action),
             json=jsonable,
         )
         self._validate_resp(resp)
+        if resp.status_code == 204:
+            return None
         return resp.json()
 
     def wrap(self, key_id, plaintext, aad=None):
@@ -662,6 +619,19 @@ class KeyProtect(BaseClient):
 
         resp = self._action(key_id, "unwrap", data)
         return base64.b64decode(resp["plaintext"].encode("utf-8"))
+
+    def rewrap(self, key_id, ciphertext, aad=None):
+        # json body needs to be a UTF-8 string
+        if isinstance(ciphertext, bytes):
+            ciphertext = ciphertext.decode("utf-8")
+
+        data = {"ciphertext": ciphertext}
+
+        if aad:
+            data["aad"] = aad
+
+        resp = self._action(key_id, "unwrap", data)
+        return resp
 
     def rotate_key(self, key_id, payload=None):
         data = None

--- a/test/integration/test_keyprotect.py
+++ b/test/integration/test_keyprotect.py
@@ -104,6 +104,23 @@ class KeyProtectTestCase(unittest.TestCase):
         unwrapped = self.kp.unwrap(key.get("id"), ciphertext, aad=["python-keyprotect"])
         self.assertEqual(message, unwrapped)
 
+    def test_wrap_rewrap_unwrap(self):
+        # create a key to be used for test
+        key = self.kp.create(name="test-key", root=True)
+        self.addCleanup(self.kp.delete, key.get("id"))
+        # wrap
+        message = b"This is a really important message."
+        wrapped = self.kp.wrap(key.get("id"), message)
+        ciphertext = wrapped.get("ciphertext")
+        # rotate
+        self.kp.rotate_key(key.get("id")) 
+        # rewrap
+        rewrapped = self.kp.rewrap(key.get("id"), ciphertext)
+        ciphertext = rewrapped.get("ciphertext")
+        # unwrap
+        unwrapped = self.kp.unwrap(key.get("id"), ciphertext)
+        self.assertEqual(message, unwrapped)
+
     def test_disable_enable_key(self):
         # create a key to be used for test
         key = self.kp.create(name="test-key", root=True)

--- a/test/integration/test_keyprotect.py
+++ b/test/integration/test_keyprotect.py
@@ -113,7 +113,7 @@ class KeyProtectTestCase(unittest.TestCase):
         wrapped = self.kp.wrap(key.get("id"), message)
         ciphertext = wrapped.get("ciphertext")
         # rotate
-        self.kp.rotate_key(key.get("id")) 
+        self.kp.rotate_key(key.get("id"))
         # rewrap
         rewrapped = self.kp.rewrap(key.get("id"), ciphertext)
         ciphertext = rewrapped.get("ciphertext")


### PR DESCRIPTION
Change the _actions method used by wrap, unwrap and rotate to use the `keys/<KEYID>/actions/ACTION` path instead of the deprecated `keys/<KEYID>?action=ACTION`. 

Add Rewrap according to API spec.